### PR TITLE
add fastcore dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ pip install autobackup
 ## How to use
 
 `autobackup src dest` will make a copy of `src` (which can be a file or
-a directory) inside `dir` in a folder with the current date+time, and
+a directory) inside `dest` in a folder with the current date+time, and
 clean up any old backups based on the following rules:
 
 - The most recent 5 backups are kept
@@ -69,5 +69,5 @@ To run this script hourly,
     sudo systemctl start backup.timer
 
 It takes additional args from fastcore’s xtra.globtastic, for example
-you can ise `-skip_folder_re '^\.\w'` to skip folders with `/.` in the
+you can use `-skip_folder_re '^\.\w'` to skip folders with `/.` in the
 name, useful for skipping cache.

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "07f04033",
    "metadata": {},
    "source": [
     "# core\n",
@@ -12,6 +13,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1cce886d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,6 +22,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4e2917d0",
    "metadata": {},
    "source": [
     "# Automated Backups\n",
@@ -35,6 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1bc2ffeb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,6 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7f3f5abe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,6 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8ae56f82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,6 +76,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3b6a2e7f",
    "metadata": {},
    "source": [
     "## The core functionality"
@@ -77,6 +84,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f3cd26d1",
    "metadata": {},
    "source": [
     "The plan has two main steps:\n",
@@ -87,6 +95,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7bac0270",
    "metadata": {},
    "source": [
     "For step 1 we want to go file by file in case of errors, and support a matching pattern for what to include. So, take 2:"
@@ -95,6 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a63af3e5",
    "metadata": {},
    "outputs": [
     {
@@ -115,6 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "78d8ba04",
    "metadata": {},
    "outputs": [
     {
@@ -135,6 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "17d1df9f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,6 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5ce256b4",
    "metadata": {},
    "outputs": [
     {
@@ -191,6 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cc80bd54",
    "metadata": {},
    "outputs": [
     {
@@ -208,6 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4aba455e",
    "metadata": {},
    "outputs": [
     {
@@ -226,6 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "25daf4af",
    "metadata": {},
    "outputs": [
     {
@@ -244,6 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e12e4c13",
    "metadata": {},
    "outputs": [
     {
@@ -261,6 +278,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "16681f68",
    "metadata": {},
    "source": [
     "The harder part is the cleanup. Let's start by generating some dates to test with."
@@ -269,6 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4473a711",
    "metadata": {},
    "outputs": [
     {
@@ -289,6 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "aaf11583",
    "metadata": {},
    "outputs": [
     {
@@ -309,6 +329,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "50c7b0f9",
    "metadata": {},
    "source": [
     "Now we want to grab the most recent 5, and then the oldest below some threshold."
@@ -317,6 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "de0b486d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,6 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fd587aa8",
    "metadata": {},
    "outputs": [
     {
@@ -363,6 +386,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9b98ae65",
    "metadata": {},
    "source": [
     "Now we want code that starts with the same test dates etc as above, but then simulates time passing by adding an hour to 'now' and a date to test dates every step then printing out a (prettified) version of clean_dates to check it's doing as I expect over a simulated month."
@@ -371,6 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ac49035e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,6 +415,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ca11004b",
    "metadata": {},
    "source": [
     "NB: Yay, it looks to be doing mostly what I want! I can collapse the output, if you're viewing this in a notebook my apologies :)"
@@ -397,6 +423,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7a4bd898",
    "metadata": {},
    "source": [
     "## Turning it into a script"
@@ -404,6 +431,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "770ef13b",
    "metadata": {},
    "source": [
     "Now that those two pieces of functionality seem to be working, we can wrap this up as a script using fastcore's call_parse, have it run the backup, clean up old files, and log any errors or messages to backup.log"
@@ -412,6 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2283e705",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -463,6 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1f159534",
    "metadata": {},
    "outputs": [
     {
@@ -479,6 +509,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2cce62db",
    "metadata": {},
    "source": [
     "Testing a directory:"
@@ -487,6 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d2d2abb0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,6 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "bc3ce8b7",
    "metadata": {},
    "outputs": [
     {
@@ -514,6 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e24795f8",
    "metadata": {},
    "outputs": [
     {
@@ -530,6 +564,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c6e19345",
    "metadata": {},
    "source": [
     "Testing a pattern"
@@ -538,6 +573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "331177a1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -547,6 +583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "586bccdd",
    "metadata": {},
    "outputs": [
     {
@@ -562,13 +599,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "python3",
-   "language": "python",
-   "name": "python3"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "077566cc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,6 +13,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2b3842ae",
    "metadata": {},
    "source": [
     "# autobackup\n",
@@ -21,6 +23,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cdc7845f",
    "metadata": {},
    "source": [
     "## Usage"
@@ -28,6 +31,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c348da14",
    "metadata": {},
    "source": [
     "### Installation"
@@ -35,6 +39,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c0cf76a0",
    "metadata": {},
    "source": [
     "Install latest from the GitHub [repository][repo]:\n",
@@ -59,6 +64,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2fe78718",
    "metadata": {},
    "source": [
     "## How to use"
@@ -66,9 +72,10 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ed2567ed",
    "metadata": {},
    "source": [
-    "`autobackup src dest` will make a copy of `src` (which can be a file or a directory) inside `dir` in a folder with the current date+time, and clean up any old backups based on the following rules:\n",
+    "`autobackup src dest` will make a copy of `src` (which can be a file or a directory) inside `dest` in a folder with the current date+time, and clean up any old backups based on the following rules:\n",
     "\n",
     "- The most recent 5 backups are kept\n",
     "- For each number of days in `--max_ages` (default is \"2,14,60\") the oldest one below that age is kept.\n",
@@ -113,19 +120,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fb96df9b",
    "metadata": {},
    "source": [
-    "It takes additional args from fastcore's xtra.globtastic, for example you can ise `-skip_folder_re '^\\.\\w'` to skip folders with `/.` in the name, useful for skipping cache."
+    "It takes additional args from fastcore's xtra.globtastic, for example you can use `-skip_folder_re '^\\.\\w'` to skip folders with `/.` in the name, useful for skipping cache."
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "python3",
-   "language": "python",
-   "name": "python3"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/settings.ini
+++ b/settings.ini
@@ -35,4 +35,5 @@ clean_ids = True
 clear_all = False
 cell_number = True
 skip_procs = 
+requirements = fastcore
 


### PR DESCRIPTION
Note: There are a bunch of `id` metadata fields bloating this change. From my understanding, these are from a difference in `nbformat` versions between `4.4` and `4.5`. These notebooks were edited on the solveit platform and `fastai` had similar metadata, so hopefully it's ok. Happy to go back and try to resolve all this.

Added:
- `fastcore` as dependency in `settings.ini`. I was getting a dependency error when using a fresh install of `autobackup`.

Changes:
- `dir` likely was meant to be `dest` to match the CLI command.
- Fixed spelling error: `ise` -> `use`.
